### PR TITLE
output_encoding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ HTTPDump.dump {
 }
 ```
 
+### HTTPDump.output_encoding=
+
+In some cases, encoding of request and response is not matched and it causes `Encoding::CompatibilityError`.
+
+`HTTPDump.output_encoding=` may resolve the issue.
+
+```ruby
+HTTPDump.output_encoding = "utf-8"
+```
+
 ### http-dump/enable
 
 ```sh

--- a/lib/http-dump.rb
+++ b/lib/http-dump.rb
@@ -3,7 +3,7 @@ require "http-dump/version"
 
 class HTTPDump
   class << self
-    attr_accessor :output, :quiet_format
+    attr_accessor :output, :quiet_format, :output_encoding
     def enable!(options = {})
       require 'webmock'
       WebMock.enable!(options)
@@ -50,7 +50,11 @@ class HTTPDump
           res << body
         end
       end
-      res.join("\n")
+      if @output_encoding
+        res.map{|d| d.force_encoding @output_encoding }.join("\n")
+      else
+        res.join("\n")
+      end
     end
   end
 end

--- a/spec/http-dump_spec.rb
+++ b/spec/http-dump_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 require 'uri'
 require 'open-uri'

--- a/spec/http-dump_spec.rb
+++ b/spec/http-dump_spec.rb
@@ -9,6 +9,7 @@ describe HTTPDump do
   before(:each) do
     HTTPDump.disable!
     HTTPDump.output = output
+    HTTPDump.output_encoding = nil
   end
 
   after(:each) do
@@ -45,6 +46,30 @@ describe HTTPDump do
       HTTPDump.dump {
         open('http://example.com/', "X-My-Header" => "foo").read
       }
+    end
+  end
+
+  context '.output_encoding=' do
+    let(:request_header_with_utf8) { {"X-My-Header" => "日本語".force_encoding("utf-8")} }
+    let(:response_body_with_ascii) { "日本語".force_encoding("ascii") }
+
+    it 'raises encoding error if encoding of request and response is not matched and output_encoding is not set' do
+      expect {
+        stub_request(:get, 'http://example.com/').to_return({:body => response_body_with_ascii, :status => 200}).times(1)
+        HTTPDump.dump {
+          open('http://example.com/', request_header_with_utf8)
+        }
+      }.to raise_error(Encoding::CompatibilityError)
+    end
+
+    it 'does not raise encoding error if encoding of request and response is not matched but output_encoding is set' do
+      expect {
+        HTTPDump.output_encoding = "utf-8"
+        stub_request(:get, 'http://example.com/').to_return({:body => response_body_with_ascii, :status => 200}).times(1)
+        HTTPDump.dump {
+          open('http://example.com/', request_header_with_utf8)
+        }
+      }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
`Net::HTTP` always returns response as `ASCII`.
So if request body contains `UTF-8` character, `Encoding::CompatibilityError` will be raised [here](https://github.com/hotchpotch/http-dump/blob/78e6712856df083a0e818aeba5898329b13a2019/lib/http-dump.rb#L53).
## Code to reproduce issue

``` ruby
require 'net/https'
require 'json'
require 'http-dump'

HTTPDump.dump {
  https = Net::HTTP.new('api.github.com', 443)
  https.use_ssl = true
  https.start {
    response = https.post('/markdown', {'mode': 'gfm', 'text': '# 日本語'}.to_json)
  }
}
```

```
$ ruby repro.rb
/usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/http-dump-0.1.0/lib/http-dump.rb:53:in `join': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/http-dump-0.1.0/lib/http-dump.rb:53:in `format'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/http-dump-0.1.0/lib/http-dump.rb:12:in `block in enable!'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/callback_registry.rb:20:in `call'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/callback_registry.rb:20:in `block in invoke_callbacks'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/callback_registry.rb:15:in `each'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/callback_registry.rb:15:in `invoke_callbacks'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:89:in `block in request'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:98:in `call'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:98:in `block in request'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:105:in `call'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:105:in `block in request'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:137:in `start_with_connect_without_finish'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:104:in `request'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:1398:in `send_entity'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:1186:in `post'
        from repro.rb:9:in `block (2 levels) in <main>'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:123:in `start_without_connect'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:150:in `start'
        from repro.rb:8:in `block in <main>'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/http-dump-0.1.0/lib/http-dump.rb:26:in `call'
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/http-dump-0.1.0/lib/http-dump.rb:26:in `dump'
        from repro.rb:5:in `<main>'
```
## Solution

So I added `HTTPDump.output_encoding` method to force encoding.

``` ruby
require 'net/https'
require 'json'
require 'http-dump'

HTTPDump.output_encoding = "utf-8" # Added this line
HTTPDump.dump {
  https = Net::HTTP.new('api.github.com', 443)
  https.use_ssl = true
  https.start {
    response = https.post('/markdown', {'mode': 'gfm', 'text': '# 日本語'}.to_json)
  }
}
```

```
$ ruby repro.rb
> POST https://api.github.com/markdown with body '{"mode":"gfm","text":"# 日本語"}' with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}
< 200 OK
< Server: GitHub.com
< Date: Sun, 02 Aug 2015 17:44:55 GMT
< Content-Type: text/html;charset=utf-8
< Content-Length: 18
< Status: 200 OK
< X-Ratelimit-Limit: 60
< X-Ratelimit-Remaining: 53
< X-Ratelimit-Reset: 1438540692
< X-Xss-Protection: 1; mode=block
< X-Frame-Options: deny
< Content-Security-Policy: default-src 'none'
< Access-Control-Allow-Credentials: true
< Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
< Access-Control-Allow-Origin: *
< X-Github-Request-Id: 6FD85868:44D4:758201E:55BE5716
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< X-Content-Type-Options: nosniff
< Vary: Accept-Encoding
< X-Served-By: a30e6f9aa7cf5731b87dfb3b9992202d
<
<h1>日本語</h1>
```
